### PR TITLE
Correct encrypted content on Scenic

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -233,7 +233,6 @@ app.get('/amp-entitlements', (req, res) => {
     res.json({
       'products': [pubId + ':news'],
       'subscriptionToken': 'subtok-' + pubId + '-' + toBase64(encrypt(email)),
-      'decryptedDocumentKey': 'yNzyxzN9YCREJtkrCtY0Zg==',
     });
   } else if (req.query.meter == '1') {
     const meter = getMeterFromCookies(req);
@@ -244,7 +243,6 @@ app.get('/amp-entitlements', (req, res) => {
           'left': meter,
           'total': MAX_METER,
         },
-        'decryptedDocumentKey': 'yNzyxzN9YCREJtkrCtY0Zg==',
       });
     } else {
       res.json({});

--- a/app/views/article-amp.html
+++ b/app/views/article-amp.html
@@ -61,8 +61,8 @@
     </script>
     <script type="application/json" cryptokeys="">
       {
-        "google.com": "AOwvsrrns+3YGnbxsXwtqnkwT0Rchco+LQjzbovfLHqrf7GWFOBP8zcEdgjMnbOpGwq9YsFbhCle/i8+aOLyU/aUSOEYd0fmGoauXf2cJ3k+h8+AL2sZzM+Yl39+qBteAVtpprbC4N2gwb727y3QAbUhDGelaFvfqfHk9dG3r+d5kD5vfhF1xgkKATfAzsAWRNG8loJO/OIFGRdLrNdjoCkjLBS3zhe17TuCKr3xhMGp3xq3htkyRZ8=",
-        "local": "AOwvsrrns+3YGnbxsXwtqnkwT0Rchco+LQjzbovfLHqrf7GWFOBP8zcEdgjMnbOpGwq9YsFbhCle/i8+aOLyU/aUSOEYd0fmGoauXf2cJ3k+h8+AL2sZzM+Yl39+qBteAVtpprbC4N2gwb727y3QAbUhDGelaFvfqfHk9dG3r+d5kD5vfhF1xgkKATfAzsAWRNG8loJO/OIFGRdLrNdjoCkjLBS3zhe17TuCKr3xhMGp3xq3htkyRZ8="
+        "google.com":"ALElAs45sv4uZ9WDhNcmTcxRtxr0WJaP2Fj/QmviGW6y8PxrsjEAPdDDbzjcY0bQd1qadCqSig4OK9nCim7GC/4OVKPzPk6++608XwOcy+X46oAsCMff0E9zjJYlKeg4tTMOEEI9PL80blVCmLLJAt+6tSojGvIVBFK0NpOcNgRS0MKbPxRYmxty8opFRn2MvqUG3tpzJJn53yWLdwA+vEK0lpF6sWdsCXWJ2uwwSZWmnBOdgHJQT3o=",
+        "local":"ALElAs6r4bvRDYy6QOpRT6LnBOJOxGIDPia3stB+xl+j/hLwPrSTHktY3s9+1aMHxYTxnhTiTaefMAEGI6jzCpVzj2a6bTcs5K6gZe3D/DYgtQdrMvvHXIIgM0pdiUSZdnuu/GEW7VHtXGObjFdF5l7tDkILk7yeXD8h0eOWM1Ndsfz1nmLo1g4RfNNlsHndfZa3IELNI/N9ppdq/XEzcGYcuaq7wAO++Ca9oT6iYp21rKmt5OzPX6o="
       }
     </script>
 
@@ -364,7 +364,7 @@ ul.related p {
             Gingerbread biscuit gummies cupcake. Powder sugar plum chocolate cake chocolate cake cake. Marzipan brownie halvah. Marzipan soufflé bear claw gummi bears muffin.
           </p>
 
-          <section class="text" subscriptions-section="content" encrypted=""><script type="application/octet-stream" ciphertext="">uojJf2GQMKvDpnuSn2jh4071kP8U0Tm+a18aE5o29GtAgWcFu5PPf63+ZYQzCIXouK+1wcRl2/Rn8vVfFxr32apw</script></section>
+          <section class="text" subscriptions-section="content" encrypted=""><script type="application/octet-stream" ciphertext="">eLSrTfzIOMWTRVKYQN6W4FcHTRDObyvejItmmU4cTe6Vx2X5oiBPvfmjrnXuJe6lmEhelPtZJVCt0MkAixU39Nr1CQgBTONpGv9ee6jw28FPZ4WVDUPak5ig8nFF</script></section>
 
           <section subscriptions-section="content">
             <p class="text">


### PR DESCRIPTION
Uses the prod key to encrypt content on Scenic instead of dev. Removes hard-coded document key so that can verify encryption works e2e with entitlements servers only.

Decrypted content should read "Encrypted chocolate bar kit kat bubblegum twix pudding encrypted."