### PR TITLE
Add call to setOnNativeSubscribeRequest for metering toast.

### DIFF
--- a/app/js/main.js
+++ b/app/js/main.js
@@ -225,6 +225,12 @@ function startFlowAuto() {
 
       // Set up metering demo controls.
       MeteringDemo.setupControls();
+      
+      // Set native response to a subscribe request. Required for metering toast.
+      subscriptions.setOnNativeSubscribeRequest(() => {
+        console.log('Starting native subscribe flow');
+        startFlow('showOffers');
+      });
 
       // Example of a timestamp representing when a given action was taken.
       const timestamp = 1597686771;


### PR DESCRIPTION
Adds a call to setOnNativeSubscribeRequest for metering toast which will cause the "Subscribe" button to work.