### PR TITLE
Metering demo: Adds lang param

### DIFF
--- a/app/js/main.js
+++ b/app/js/main.js
@@ -229,6 +229,9 @@ function startFlowAuto() {
       // Forget any subscriptions, for metering demo purposes.
       subscriptions.clear();
 
+      // Set up metering demo language.
+      document.documentElement.lang = getQueryParams().lang || 'en';
+
       // Set up metering demo controls.
       MeteringDemo.setupControls();
 


### PR DESCRIPTION
This PR adds a `lang` URL param to the metering demo. This param affects the Regwall