### PR TITLE
Added parameterized client id to js instantiation

### DIFF
--- a/app/views/signin.html
+++ b/app/views/signin.html
@@ -106,7 +106,7 @@
         gapi.load('auth2', function () {
           auth2 = gapi.auth2.init({
             client_id:
-              '520465458218-e9vp957krfk2r0i4ejeh6aklqm7c25p4.apps.googleusercontent.com',
+              '<% googleSignInClientId %>',
             scope: 'profile email',
           });
         });


### PR DESCRIPTION
Missed this one spot for using an env var to properly set the google sign-in client id.