### PR TITLE
Fetches Showcase entitlement server-side, then consumes it client-side

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -177,8 +177,8 @@ app.get(
     // Mock a registration timestamp, for demo purposes.
     const registrationTimestamp = Math.floor(Date.now() / 1000);
 
-    // Define params for requesting a Showcase entitlement.
-    const jsonParams = {
+    // Prepare a request for a Showcase entitlement.
+    const showcaseEntitlementRequestParams = {
       'metering': {
         'clientTypes': [
           1, // Just pass 1 here
@@ -202,7 +202,9 @@ app.get(
 
     // Encode params as Base64 for URLs.
     // https://en.wikipedia.org/wiki/Base64#URL_applications
-    const encodedParams = Buffer.from(JSON.stringify(jsonParams))
+    const encodedParams = Buffer.from(
+      JSON.stringify(showcaseEntitlementRequestParams)
+    )
       .toString('base64')
       .replace(/\+/g, '-')
       .replace(/\//g, '_')

--- a/app/app.js
+++ b/app/app.js
@@ -177,7 +177,7 @@ app.get(
     // Mock a registration timestamp, for demo purposes.
     const registrationTimestamp = Math.floor(Date.now() / 1000);
 
-    // Define Showcase entitlement request params.
+    // Define params for requesting a Showcase entitlement.
     const jsonParams = {
       'metering': {
         'clientTypes': [

--- a/app/app.js
+++ b/app/app.js
@@ -177,7 +177,7 @@ app.get(
     // Mock a registration timestamp, for demo purposes.
     const registrationTimestamp = Math.floor(Date.now() / 1000);
 
-    // Request Showcase entitlement.
+    // Define Showcase entitlement request params.
     const jsonParams = {
       'metering': {
         'clientTypes': [
@@ -199,16 +199,29 @@ app.get(
         },
       },
     };
-    const encodedParams = Buffer.from(JSON.stringify(jsonParams)).toString(
-      'base64'
-    );
+
+    // Encode params as Base64 for URLs.
+    // https://en.wikipedia.org/wiki/Base64#URL_applications
+    const encodedParams = Buffer.from(JSON.stringify(jsonParams))
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/[=]+$/g, '');
+
+    // Request a Showcase entitlement.
     const showcaseEntitlementRequest = `https://news.google.com/swg/_/api/v1/publication/${config.publicationId}/entitlements?encodedParams=${encodedParams}`;
     const showcaseEntitlementResponse = await fetch(
       showcaseEntitlementRequest
     ).then((res) => res.json());
+
+    // Extract the Showcase entitlement JWT.
     const showcaseEntitlementJwt =
       showcaseEntitlementResponse.signedEntitlements;
 
+    // Render the page.
+    // If the Showcase entitlement JWT exists, then the article will:
+    // - Render unlocked
+    // - Include additional JS to consume the Showcase entitlement
     res.render('../app/views/showcase-article-with-server-side-paywall', {
       swgJsUrl: getSwgJsUrl(req),
       swgGaaJsUrl: getSwgGaaJsUrl(req),

--- a/app/app.js
+++ b/app/app.js
@@ -16,7 +16,13 @@
 
 const fetch = require('node-fetch');
 const jsonwebtoken = require('jsonwebtoken');
-const {decrypt, encrypt, fromBase64, toBase64} = require('./crypto');
+const {
+  decrypt,
+  encrypt,
+  fromBase64,
+  toBase64,
+  toBase64Url,
+} = require('./crypto');
 const {getConfig} = require('./config');
 
 const app = (module.exports = require('express').Router());
@@ -202,13 +208,9 @@ app.get(
 
     // Encode params as Base64 for URLs.
     // https://en.wikipedia.org/wiki/Base64#URL_applications
-    const encodedParams = Buffer.from(
+    const encodedParams = toBase64Url(
       JSON.stringify(showcaseEntitlementRequestParams)
-    )
-      .toString('base64')
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_')
-      .replace(/[=]+$/g, '');
+    );
 
     // Request a Showcase entitlement.
     const showcaseEntitlementRequest = `https://news.google.com/swg/_/api/v1/publication/${config.publicationId}/entitlements?encodedParams=${encodedParams}`;

--- a/app/app.js
+++ b/app/app.js
@@ -170,9 +170,14 @@ app.get(
     const setup = getSetup(req);
     const config = getConfig(req.params.configId);
 
-    // Request Showcase entitlement.
+    // Mock a publisher provided user ID, for demo purposes.
     const publisherProvidedId =
       'ppidfromscenic' + Math.floor(Math.random() * 9999999999);
+
+    // Mock a registration timestamp, for demo purposes.
+    const registrationTimestamp = Math.floor(Date.now() / 1000);
+
+    // Request Showcase entitlement.
     const jsonParams = {
       'metering': {
         'clientTypes': [
@@ -188,7 +193,7 @@ app.get(
           'attributes': [
             {
               'name': 'standard_registered_user',
-              'timestamp': 1608162166, // Pass registration timestamp in seconds
+              'timestamp': registrationTimestamp, // Pass registration timestamp in seconds
             },
           ],
         },

--- a/app/app.js
+++ b/app/app.js
@@ -57,8 +57,9 @@ const DECRYPTED_DOCUMENT_KEY = 'd4ZoJQJLWrV6DiF9oI40fw==';
 
 const ARTICLES = require('./content').ARTICLES;
 
-const googleSignInClientId = process.env.GSI_CLIENT_ID ||
-   '520465458218-e9vp957krfk2r0i4ejeh6aklqm7c25p4.apps.googleusercontent.com';
+const googleSignInClientId =
+  process.env.GSI_CLIENT_ID ||
+  '520465458218-e9vp957krfk2r0i4ejeh6aklqm7c25p4.apps.googleusercontent.com';
 
 /**
  * Maps AMP reader IDs to emails from Google Sign-In.
@@ -90,7 +91,7 @@ app.get(['/', '/config/:configId'], (req, res) => {
     title: 'Select an article to get started',
     config: getConfig(req.params.configId),
     articles: ARTICLES,
-    gsv: process.env.GOOGLE_SITE_VERIFICATION || null
+    gsv: process.env.GOOGLE_SITE_VERIFICATION || null,
   });
 });
 
@@ -119,7 +120,7 @@ app.get(['/config/:configId/((\\d+))', '/((\\d+))'], (req, res) => {
     article,
     prev: prevId,
     next: nextId,
-    googleSignInClientId
+    googleSignInClientId,
   });
 });
 
@@ -157,6 +158,65 @@ app.get(['/config/:configId/((\\d+)).amp', '/((\\d+)).amp'], (req, res) => {
 });
 
 /**
+ * A Showcase article with a server-side paywall.
+ */
+app.get(
+  [
+    '/config/:configId/showcase-article-with-server-side-paywall',
+    '/showcase-article-with-server-side-paywall',
+  ],
+  async (req, res) => {
+    const article = ARTICLES[0];
+    const setup = getSetup(req);
+    const config = getConfig(req.params.configId);
+
+    // Request Showcase entitlement.
+    const publisherProvidedId =
+      'ppidfromscenic' + Math.floor(Math.random() * 9999999999);
+    const jsonParams = {
+      'metering': {
+        'clientTypes': [
+          1, // Just pass 1 here
+        ],
+        'owner': 'scenic-2017.appspot.com', // Pass your publicationID here
+        'resource': {
+          'hashedCanonicalUrl':
+            '37d9f8ef6e6a2f3e153959b7c126d73cbc9d1d0549ab2a0b389516122cb960d562cbd4cc7d4c8b1b2e488f073c557645088ea2d60f959f847e8b7e7cee931eaf', // Pass your article's hashed canonical URL here
+        },
+        'state': {
+          'id': publisherProvidedId, // Pass your reader's hashed ID
+          'attributes': [
+            {
+              'name': 'standard_registered_user',
+              'timestamp': 1608162166, // Pass registration timestamp in seconds
+            },
+          ],
+        },
+      },
+    };
+    const encodedParams = Buffer.from(JSON.stringify(jsonParams)).toString(
+      'base64'
+    );
+    const showcaseEntitlementRequest = `https://news.google.com/swg/_/api/v1/publication/${config.publicationId}/entitlements?encodedParams=${encodedParams}`;
+    const showcaseEntitlementResponse = await fetch(
+      showcaseEntitlementRequest
+    ).then((res) => res.json());
+    const showcaseEntitlementJwt =
+      showcaseEntitlementResponse.signedEntitlements;
+
+    res.render('../app/views/showcase-article-with-server-side-paywall', {
+      swgJsUrl: getSwgJsUrl(req),
+      swgGaaJsUrl: getSwgGaaJsUrl(req),
+      setup,
+      serviceBase: BASE_URL,
+      config,
+      article,
+      showcaseEntitlementJwt,
+    });
+  }
+);
+
+/**
  * RSS Feed.
  */
 app.get('/feed.xml', (req, res) => {
@@ -181,7 +241,7 @@ app.get('/subscribe', (req, res) => {
   res.render('../app/views/signin', {
     'type_subscribe': true,
     'returnUrl': returnUrl,
-    googleSignInClientId
+    googleSignInClientId,
   });
 });
 
@@ -194,7 +254,7 @@ app.get('/signin', (req, res) => {
   res.render('../app/views/signin', {
     'type_signin': true,
     'returnUrl': returnUrl,
-    googleSignInClientId
+    googleSignInClientId,
   });
 });
 
@@ -342,7 +402,7 @@ app.post('/amp-pingback', (req, res) => {
 app.get('/gsi-iframe', (req, res) => {
   res.render('../app/views/gsi-signin-iframe', {
     swgGaaJsUrl: getSwgGaaJsUrl(req),
-    googleSignInClientId
+    googleSignInClientId,
   });
 });
 

--- a/app/crypto.js
+++ b/app/crypto.js
@@ -39,6 +39,7 @@ exports.decrypt = function (s) {
 };
 
 /**
+ * Returns a Base64 string.
  * @param {string} s
  * @return {string}
  */
@@ -47,6 +48,20 @@ exports.toBase64 = function (s) {
 };
 
 /**
+ * Returns a URL-safe Base64 string.
+ * @param {string} s
+ * @return {string}
+ */
+exports.toBase64Url = function (s) {
+  return exports
+    .toBase64(s)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/[=]+$/g, '');
+};
+
+/**
+ * Returns a string decoded from a Base64 string.
  * @param {string} s
  * @return {string}
  */

--- a/app/views/showcase-article-with-server-side-paywall.html
+++ b/app/views/showcase-article-with-server-side-paywall.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width,minimum-scale=1,initial-scale=1"
+    />
+    <link rel="canonical" href="." />
+    <title>Showcase article with server-side paywall</title>
+
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Playfair+Display"
+      type="text/css"
+    />
+    <link
+      href="https://fonts.googleapis.com/css?family=Muli"
+      rel="stylesheet"
+      type="text/css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700"
+      type="text/css"
+    />
+    <link rel="stylesheet" href="/styles.css" type="text/css" />
+    <link rel="icon" type="image/png" href="/icons/icon-2x.png" />
+    <meta name="theme-color" content="#37dc8c" />
+    <link rel="apple-touch-icon" href="/icons/icon-2x.png" />
+    <meta name="msapplication-TileImage" content="/icons/icon-2x.png" />
+    <meta name="msapplication-TileColor" content="#37dc8c" />
+
+    <script type="application/ld+json">
+      {
+        "@context": "http://schema.org",
+        "@type": "NewsArticle",
+        "headline": "Article title",
+        "image": "https://scenic-2017.appspot.com/icons/icon-2x.png",
+        "datePublished": "2025-02-05T08:00:00+08:00",
+        "dateModified": "2025-02-05T09:20:00+08:00",
+        "author": {
+          "@type": "Person",
+          "name": "John Doe"
+        },
+        "publisher": {
+          "name": "<% config.name %>",
+          "@type": "Organization",
+          "@id": "scenic-2017.appspot.com",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://scenic-2017.appspot.com/icons/icon-2x.png"
+          }
+        },
+        "description": "A most wonderful article",
+        "isAccessibleForFree": "False",
+        "isPartOf": {
+          "@type": ["CreativeWork", "Product"],
+          "name": "Scenic News",
+          "productID": "<% config.publicationId %>:news"
+        }
+      }
+    </script>
+    <script src="<% swgGaaJsUrl %>"></script>
+    <script async subscriptions-control="manual" src="<% swgJsUrl %>"></script>
+    <script src="https://apis.google.com/js/platform.js" async defer></script>
+  </head>
+  <body>
+    <div class="main-body">
+      <header>
+        <a class="brand-header" href="/">
+          <div class="brand-logo"></div>
+          <div class="brand-name"><% config.name %></div>
+        </a>
+      </header>
+
+      <main role="main">
+        <div class="container">
+          <h1 class="heading">Showcase article with server-side paywall</h1>
+          <div class="hr"></div>
+
+          <!-- Free paragraph -->
+          <p class="text">
+            This is the intro paragraph. You can read this paragraph even
+            without entitlements to the article.
+          </p>
+
+          <!-- Paid paragraph. Only users with a Showcase entitlement see this. -->
+          <%# showcaseEntitlementJwt %>
+          <p class="text">
+            🎉 This is the paywalled paragraph. If you're reading this, you have
+            a Showcase entitlement. Congrats!
+          </p>
+          <div class="hr"></div>
+          <%/ showcaseEntitlementJwt %>
+
+          <!-- Paywall. Only users WITHOUT a Showcase entitlement see this. -->
+          <%^ showcaseEntitlementJwt %>
+          <p class="text">
+            <strong>🔒 Register to read more.</strong>
+          </p>
+          <%/ showcaseEntitlementJwt %>
+        </div>
+      </main>
+    </div>
+    <div class="comments">
+      <a href="/setup"> Setup </a>
+    </div>
+
+    <!-- Consume the Showcase entitlement, if it exists. -->
+    <%# showcaseEntitlementJwt %>
+    <script>
+      (self.SWG = self.SWG || []).push(function (subscriptions) {
+        // Create a new variable based on the "signedEntitlements"
+        // field in your response.
+        var showcaseEntitlementJwt = '<% showcaseEntitlementJwt %>';
+
+        // Consume the entitlement.
+        // This triggers the "You're getting more with Google" UX flow.
+        subscriptions.consumeShowcaseEntitlementJwt(showcaseEntitlementJwt);
+      });
+    </script>
+    <%/ showcaseEntitlementJwt %>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds a new page to Scenic "/showcase-article-with-server-side-paywall". The server fetches Showcase entitlements for this page, then unlocks a server-side paywall, and adds JS to consume the Showcase entitlement client-side