### PR TITLE
Showcase Regwall: Adds `html_lang` param for testing languages

### DIFF
--- a/app/js/main.js
+++ b/app/js/main.js
@@ -204,6 +204,9 @@ function setupMeteringDemo(subscriptions) {
   // Set up metering demo controls.
   MeteringDemo.setupControls();
 
+  // Set up language.
+  MeteringDemo.setupLanguage();
+
   // Handle clicks on the Metering Toast's "Subscribe" button.
   subscriptions.setOnNativeSubscribeRequest(() => {
     // Show a publisher paywall for demo purposes.

--- a/app/js/metering.js
+++ b/app/js/metering.js
@@ -11,6 +11,19 @@ export const MeteringDemo = {
   /** URL of iframe containing a Google Sign-In button. */
   GOOGLE_SIGN_IN_IFRAME_URL: 'https://scenic-2017.appspot.com/gsi-iframe',
 
+  /** Optionally updates the HTML tag's `lang` attribute. */
+  setupLanguage: () => {
+    // Check for optional URL variable.
+    const languageCodeMatch = location.search.match(
+      /html_lang=([A-Za-z0-9-]+)/
+    );
+    if (languageCodeMatch) {
+      // Update HTML tag's `lang` attribute.
+      const languageCode = languageCodeMatch[1];
+      document.documentElement.lang = languageCode;
+    }
+  },
+
   /** Sets up controls for the metering demo. */
   setupControls: () => {
     // Wire up buttons.


### PR DESCRIPTION
The `html_lang` URL param helps you test different languages for the Showcase Regwall. For instance, you could add "&html_lang=de" to your URL to see the Showcase Regwall in German. Note: This only works on Scenic