### PR TITLE
fix: this was using the wrong path

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -469,8 +469,8 @@ app.get('/production-swg-js-with-custom-server-url', async (req, res) => {
   const customizedSwgJs = swgJs
     .replace(/"https:\/\/news.google.com"/g, `"${setup.scriptCustomServerUrl}"`)
     .replace(
-      /"https:\/\/news.google.com\/_/g,
-      `"${setup.scriptCustomServerUrl}/_`
+      /"https:\/\/news.google.com\/swg\/_/g,
+      `"${setup.scriptCustomServerUrl}/swg/_`
     );
   res.send(customizedSwgJs);
 });


### PR DESCRIPTION
Was seeing calls go to prod endpoint instead of my local. Looked through the local file and confirmed the serviceUrl has `https://news.google.com/swg/_` instead of `https://news.google.com/_`, which the old regex was replacing