### PR TITLE
downgrade node-fetch to 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "jsonwebtoken": "8.5.1",
     "lazypipe": "1.0.2",
     "minimist": "1.2.5",
-    "node-fetch": "3.1.0",
+    "node-fetch": "2.6.0",
     "nodemon": "2.0.15",
     "plugin-error": "1.0.1",
     "prettier": "2.4.1",


### PR DESCRIPTION
2.6.0 is the last non-module version of node-fetch