### PR TITLE
Correct logic for showing the registration prompt

### DIFF
--- a/app/js/main.js
+++ b/app/js/main.js
@@ -282,7 +282,7 @@ function setupMeteringDemo(subscriptions) {
         document.body.style.overflow = 'hidden';
 
         // Skip metering regwall for registered users.
-        if (meteringState.registrationTimestamp) {
+        if ('registrationTimestamp' in meteringState && typeof meteringState.registrationTimestamp !== 'undefined') {
           return meteringState;
         }
 


### PR DESCRIPTION
At the moment, `registrationTimestamp` is always set even if it's not available in local storage: https://github.com/subscriptions-project/scenic-demo/blob/main/app/js/metering.js#L109

This causes issues with the check as it is, hence expanding to explicitly look for when the `registrationTimestamp` is `undefined`.