### PR TITLE
Make swg.experiments sticky for a browser session

### DIFF
--- a/app/js/main.js
+++ b/app/js/main.js
@@ -534,3 +534,33 @@ function getQueryParams() {
 
 // Initiates the flow, if valid.
 startFlowAuto();
+
+/**
+ * Function for adding "sticky" experiments to a users browser session
+ * so they can keep experiment settings across multiple page visits for
+ * a given tab.
+ */
+function handleHashChange() {
+  const hashUrlSearchParams = new URLSearchParams(location.hash.substring(1));
+  const sessionSwgExperiments = sessionStorage.getItem('swgExperiments');
+
+  if (hashUrlSearchParams.has('swg.experiments')) {
+    if (hashUrlSearchParams.get('swg.experiments') === sessionSwgExperiments) {
+      return;
+    }
+
+    sessionStorage.setItem(
+      'swgExperiments',
+      hashUrlSearchParams.get('swg.experiments')
+    );
+  } else {
+    if (sessionSwgExperiments) {
+      hashUrlSearchParams.append('swg.experiments', sessionSwgExperiments);
+      window.location.hash = hashUrlSearchParams.toString();
+    }
+  }
+}
+
+window.addEventListener('hashchange', handleHashChange, false);
+// need to invoke for initial load
+handleHashChange();


### PR DESCRIPTION
Internal ticket: b/255386765

Makes the `swg.experiments` value in the fragment sticky for a user during a browser session. This is helpful for testing when you may need to navigate but keep experiments configured. It follows these rules:
1) no value in session, new fragment - save fragment in storage
2) value in session, new fragment - replace storage with new fragment
3) value in session, no fragment - add fragment to url

Since this uses session storage, you can use a different tab or clear session storage to remove it from being sticky.

![sticky-experiments](https://user-images.githubusercontent.com/1211229/200397445-479fd0b3-f3c4-47ac-b245-4609d357e7ad.gif)
